### PR TITLE
async@1.5.1 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "ampersand-model": "^6.0.2",
-    "async": "^1.5.0",
+    "async": "^1.5.1",
     "debug": "^2.2.0",
     "event-stream": "^3.3.2",
     "lodash.omit": "^3.1.0",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[async](https://www.npmjs.com/package/async) just published its new version 1.5.1, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>


Happy fixing and merging :palm_tree:

---
The new version differs by 25 commits .

- [`625a2e1`](https://github.com/caolan/async/commit/625a2e11fa0604a52aaec57acb6075c49325f4a9) `Version 1.5.1`
- [`5a9383b`](https://github.com/caolan/async/commit/5a9383b3a2c554e19d96aa9918e5e26b37d773d7) `update minified build`
- [`94868a2`](https://github.com/caolan/async/commit/94868a2b8004952601eecbd8a72e43870a2a2b09) `update changelog for 1.5.1`
- [`1604c74`](https://github.com/caolan/async/commit/1604c741310a1f75f5e135621c2dc9acf0699d3f) `Merge pull request #993 from gr2m/master`
- [`f360e0d`](https://github.com/caolan/async/commit/f360e0d6d21c0fd9942252358d03b223a8ea42e7) `fix: auto stops after error #988`
- [`f556b20`](https://github.com/caolan/async/commit/f556b202d418c59de8f76e409d82c75b12f5a9ca) `test: auto stops after error #988`
- [`b9cc289`](https://github.com/caolan/async/commit/b9cc28973144a9e1a84184d9d0bf48749899bfd9) `Merge pull request #980 from charlierudolph/patch-1`
- [`761d83b`](https://github.com/caolan/async/commit/761d83bab51ddc09484f131f0181d50283c6cc47) `fix typo in #971`
- [`f9f6204`](https://github.com/caolan/async/commit/f9f62043460e16db0f5bf42045228db150590171) `Merge pull request #966 from ex1st/master`
- [`c744ab6`](https://github.com/caolan/async/commit/c744ab6ac21971b806073f44ab51e150f23bfd2b) `Added test for auto with concurrency but without callback.`
- [`0c60ded`](https://github.com/caolan/async/commit/0c60dedb47073a149f9bb52057563b20857eabfd) `Merge pull request #971 from hotaru355/master`
- [`0469948`](https://github.com/caolan/async/commit/0469948b230196bdb4e8e51e0df50853ad2d0d17) `Bug fix #968: uddate Readme for `async.every()``
- [`3803e08`](https://github.com/caolan/async/commit/3803e0892e6ea9c0372ccdd7467d703922c0cf50) `Fixed incorrect handling of arguments in "auto" in case of empty callback`
- [`a92b163`](https://github.com/caolan/async/commit/a92b163ec46e36eef828c620543aa88e95c48b1f) `Update CHANGELOG.md`
- [`e7b334c`](https://github.com/caolan/async/commit/e7b334c20f4b4c9c7f438f93e64af6c640a0360b) `Merge pull request #963 from benfleis/master`


There are 25 commits in total. See the [full diff](https://github.com/caolan/async/compare/621f13805aa326865b85dbbf7128baf7146ab976...625a2e11fa0604a52aaec57acb6075c49325f4a9).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>